### PR TITLE
Fix KittyPanel::createOrShow to change an image for each click

### DIFF
--- a/src/KittyPanel.ts
+++ b/src/KittyPanel.ts
@@ -20,7 +20,6 @@ class KittyPanel {
 
     public static async createOrShow(extensionPath: string, secrets: vscode.SecretStorage) {
         const column = vscode.window.activeTextEditor ? vscode.window.activeTextEditor.viewColumn : undefined;
-        let configChange = false;
         let apiKey = await secrets.get("apiKey");
         console.log(apiKey);
         vscode.workspace.onDidChangeConfiguration(async () => {
@@ -30,15 +29,12 @@ class KittyPanel {
                 KittyPanel.currentPanel = new KittyPanel(column || vscode.ViewColumn.One, extensionPath, apiKey);
                 console.log("@@@@@@@");
                 if (currentDocument) { vscode.window.showTextDocument(currentDocument, column);}
-                configChange = true;
             }
         });
         
         if (KittyPanel.currentPanel) {
-            if (!configChange){
-                configChange = false;
-                KittyPanel.currentPanel._panel.reveal(column);
-            }
+            KittyPanel.currentPanel._panel.reveal(column);
+            KittyPanel.currentPanel._update();
         } else {
             console.log("@@@@");
             KittyPanel.currentPanel = new KittyPanel(column || vscode.ViewColumn.One, extensionPath, apiKey);


### PR DESCRIPTION
I think, programmers need many cats to program more efficiently.

KittyPanel::createOrShow is fixed to change an image for each click as shown in the GIF image below.
![](https://i.gyazo.com/b5f87eea901fb180f93b30cd34dc53af.gif)